### PR TITLE
Create .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+language: common-lisp
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - libc6-i386
+      - openjdk-7-jre
+
+env:
+  global:
+    - PATH=~/.roswell/bin:$PATH
+    - ROSWELL_INSTALL_DIR=$HOME/.roswell
+  matrix:
+    - LISP=abcl-bin
+    - LISP=allegro
+    - LISP=ccl-bin
+    - LISP=ccl32
+    - LISP=clisp
+    - LISP=ecl
+    - LISP=sbcl-bin
+    - LISP=cmu-bin
+
+
+install:
+  - curl -L https://raw.githubusercontent.com/roswell/roswell/master/scripts/install-for-ci.sh | sh
+
+cache:
+  directories:
+    - $HOME/.roswell
+    - $HOME/.config/common-lisp
+
+script:
+  - ros -e "(cl:in-package :cl-user)
+            (ql:quickload :cl-unicode/test :verbose t)
+            (uiop:quit (if (cl-unicode-test:run-all-tests)
+                          0 1))"


### PR DESCRIPTION
This adds a script to run the tests using TravisCI.  Travis would need to be enabled for edicl/cl-unicode on [travis-ci.org](http://travis-ci.org).  By having tests run on Travis when code is committed, it allows checking that tests run on all implementations and it becomes easier to determine if a failing test is new by checking Travis's previous runs with the new version.

The tests are run by calling `cl-unicode-test:run-all-tests` and failing the job if nil is returned.

Currently, the tests are failing.  There are missing derived properties failures on all implementations.  Ecl, sbcl, and cmu all have other failing tests in the simple test suite.

Roswell is used as the implementation manager.  This adds abcl, allegro, ccl, ccl32, clisp, ecl, sbcl and cmu as implementations to test, which are (I think) all the versions supported by Roswell, except for clasp.  Clasp isn't tested because it has a 1-2 hour build time and times out on Travis.