### PR TITLE
Ignore test/normalization-forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ hash-tables.lisp
 lists.lisp
 methods.lisp
 test/derived-properties
+test/normalization-forms


### PR DESCRIPTION
This is generated by the cl-unicode build process.