### PR TITLE
Make cl-unicode able to be upgraded in a different src dir

### DIFF
--- a/build/util.lisp
+++ b/build/util.lisp
@@ -29,8 +29,8 @@
 
 (in-package :cl-unicode)
 
-(defvar *this-file* (load-time-value
-                     (or #.*compile-file-pathname* *load-pathname*))
+(defparameter *this-file* (load-time-value
+                           (or #.*compile-file-pathname* *load-pathname*))
   "The location of this source file.  Needed to find the data files.")
 
 (defvar *char-database* nil


### PR DESCRIPTION
I updated my quicklisp dist today and found myself unable to load cl-unicode due to being unable to find `lists.lisp`

By using `defparameter`, allow picking up new location for `*this-file*`, allowing the generators to pick up the new location